### PR TITLE
python3-distutils deprecated

### DIFF
--- a/build_notes.txt
+++ b/build_notes.txt
@@ -1,0 +1,9 @@
+#build_notes.txt
+Updating all git submodules
+Submodule 'linux' (https://github.com/smaeul/linux) registered for path 'linux'
+Submodule 'opensbi' (https://github.com/smaeul/opensbi) registered for path 'opensbi'
+Submodule 'riscv-gnu-toolchain' (https://github.com/riscv/riscv-gnu-toolchain) registered for path 'riscv-gnu-toolchain'
+Submodule 'rtl8723ds' (https://github.com/lwfinger/rtl8723ds.git) registered for path 'rtl8723ds'
+Submodule 'sun20i_d1_spl' (https://github.com/smaeul/sun20i_d1_spl) registered for path 'sun20i_d1_spl'
+Submodule 'u-boot' (https://github.com/smaeul/u-boot.git) registered for path 'u-boot'
+Cloning into '/home/frodo/sbc/riscv/10_JamesGraves_LicheeDebian/linux'...

--- a/prepare_debian_host.sh
+++ b/prepare_debian_host.sh
@@ -6,6 +6,6 @@ sudo apt install \
 	autoconf automake autotools-dev curl python3 libmpc-dev \
 	libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo \
 	gperf libtool patchutils bc zlib1g-dev libexpat-dev swig \
-	libssl-dev python3-distutils python3-dev \
+	libssl-dev  python3-dev \
 	debootstrap debian-ports-archive-keyring \
 	qemu-user-static qemu-system qemu-utils qemu-system-misc binfmt-support

--- a/prepare_debian_host.sh
+++ b/prepare_debian_host.sh
@@ -6,6 +6,6 @@ sudo apt install \
 	autoconf automake autotools-dev curl python3 libmpc-dev \
 	libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo \
 	gperf libtool patchutils bc zlib1g-dev libexpat-dev swig \
-	libssl-dev  python3-dev \
+	libssl-dev python3-setuptools python3-dev \
 	debootstrap debian-ports-archive-keyring \
 	qemu-user-static qemu-system qemu-utils qemu-system-misc binfmt-support


### PR DESCRIPTION
changed the `prepare_debian_host.sh' to use `python3-setuptools' instead.